### PR TITLE
Add a method close co with error

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,42 @@
+# http://editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+end_of_line = lf
+charset = utf-8
+tab_width = 4
+# Width of Github's online editor/diff display
+max_line_length = 119
+
+# Use 2 spaces for the HTML files
+[*.html]
+indent_size = 2
+
+# The JSON files contain newlines inconsistently
+[*.json]
+indent_size = 2
+insert_final_newline = ignore
+
+# Minified JavaScript files shouldn't be changed
+[**.min.js]
+indent_style = ignore
+insert_final_newline = ignore
+
+# Makefiles always use tabs for indentation
+[Makefile]
+indent_style = tab
+
+# Batch files use tabs for indentation
+[*.bat]
+indent_style = tab
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.yml]
+indent_size = 2

--- a/README.rst
+++ b/README.rst
@@ -68,7 +68,7 @@ Creation
         change_request = co_handler.create_change_request('Title', 'Description', 'assignment_group')
 
 
-Updation
+Updating
 --------
 ``ChangeRequestHandler.update_change_request`` method signature:
 
@@ -117,6 +117,32 @@ Closing
 
         co_handler.close_change_request(change_request)
 
+Closing with error
+------------------
+``ChangeRequestHandler.close_change_request_with_error`` method signature:
+
+**Parameters**
+
+* ``change_request`` - The ``ChangeRequest`` Model representing the Change Order to be closed with error
+* ``payload`` - The payload to pass to the ServiceNow REST API.
+
+**Example**
+
+.. code-block:: python
+
+    from django_snow.models import ChangeRequest
+    from django_snow.helpers import ChangeRequestHandler
+
+    def change_data(self):
+        change_request = ChangeRequest.objects.filter(...)
+        co_handler = ChangeRequestHandler()
+
+        payload = {
+                    'description': 'updated description',
+                    'title': 'foo'
+                  }
+
+        co_handler.close_change_request_with_error(change_request, payload)
 
 Models
 ======

--- a/django_snow/helpers/snow_request_handler.py
+++ b/django_snow/helpers/snow_request_handler.py
@@ -58,26 +58,38 @@ class ChangeRequestHandler:
         return change_request
 
     def close_change_request(self, change_request):
-        """
-        Mark the change request as completed
-        """
+        """Mark the change request as completed."""
+
         payload = {'state': ChangeRequest.TICKET_STATE_COMPLETE}
         self.update_change_request(change_request, payload)
 
     def close_change_request_with_error(self, change_request, payload):
-        """
-        Mark the change request as completed with error
+        """Mark the change request as completed with error.
+
+        The possible keys for the payload are:
+            * `title`
+            * `description`
+
+        :param change_request: The change request to be closed
+        :type change_request: :class:`django_snow.models.ChangeRequest`
+        :param payload: A dict of data to be updated while closing change request
+        :type payload: dict
         """
         payload['state'] = ChangeRequest.TICKET_STATE_COMPLETE_WITH_ERRORS
         self.update_change_request(change_request, payload)
 
     def update_change_request(self, change_request, payload):
-        """
-        Update the change request with the data from the kwargs
-        The possible values for the kwargs keys are :
+        """Update the change request with the data from the kwargs.
+
+        The possible keys for the payload are:
             * `title`
             * `description`
             * `state`
+
+        :param change_request: The change request to be updated
+        :type change_request: :class:`django_snow.models.ChangeRequest`
+        :param payload: A dict of data to be updated while updating the change request
+        :type payload: dict
         """
         client = self._get_client()
 

--- a/django_snow/helpers/snow_request_handler.py
+++ b/django_snow/helpers/snow_request_handler.py
@@ -64,6 +64,13 @@ class ChangeRequestHandler:
         payload = {'state': ChangeRequest.TICKET_STATE_COMPLETE}
         self.update_change_request(change_request, payload)
 
+    def close_change_request_with_error(self, change_request, payload):
+        """
+        Mark the change request as completed with error
+        """
+        payload['state'] = ChangeRequest.TICKET_STATE_COMPLETE_WITH_ERRORS
+        self.update_change_request(change_request, payload)
+
     def update_change_request(self, change_request, payload):
         """
         Update the change request with the data from the kwargs

--- a/testapp/tests.py
+++ b/testapp/tests.py
@@ -98,6 +98,17 @@ class TestChangeRequestHandler(TestCase):
 
         mock_update_request.assert_called_with('some change order', {'state': ChangeRequest.TICKET_STATE_COMPLETE})
 
+    @mock.patch('django_snow.helpers.snow_request_handler.ChangeRequestHandler.update_change_request')
+    def test_close_change_request_with_error(self, mock_update_request, mock_pysnow):
+        mock_update_request.return_value = 'foo'
+        change_request_handler = ChangeRequestHandler()
+        payload = {'description': 'foo'}
+        change_request_handler.close_change_request_with_error('some change order', payload)
+
+        mock_update_request.assert_called_with(
+            'some change order', {'state': ChangeRequest.TICKET_STATE_COMPLETE_WITH_ERRORS, 'description': 'foo'}
+        )
+
     def test_update_change_request(self, mock_pysnow):
         fake_query = mock.MagicMock()
         fake_change_order = mock.MagicMock()


### PR DESCRIPTION
Add a new method called close_change_request_with_error. This will add the ability to close a change request with state TICKET_STATE_COMPLETE_WITH_ERRORS. The user has the ability to send in a payload such as description, title etc. etc.